### PR TITLE
Fix Safari instructions popup height

### DIFF
--- a/Balance iOS/Scenes/Home/SafariStepsController.swift
+++ b/Balance iOS/Scenes/Home/SafariStepsController.swift
@@ -68,10 +68,13 @@ class SafariStepsController: NativeHeaderController {
             default:
                 break
             }
-            currrentYPosition = view.frame.maxY + NativeLayout.Spaces.default_more
+            // _UIScrollViewIndicator
+            if !view.className.starts(with: "_") {
+                currrentYPosition = view.frame.maxY + NativeLayout.Spaces.default_more
+            }
         }
         
-        scrollView.contentSize = .init(width: scrollView.frame.width, height: currrentYPosition + actionToolbarView.frame.height + NativeLayout.Spaces.default_double)
+        scrollView.contentSize = .init(width: scrollView.frame.width, height: currrentYPosition)
     }
     
     class SafariStepArrowView: SPView {


### PR DESCRIPTION
The calculation was taking into account the scroll view indicator `maxY`. Looked good only on large devices.

https://user-images.githubusercontent.com/8790386/151565848-cd7122cb-a2ad-4038-93f5-ec0e4b1c17ca.mov

https://user-images.githubusercontent.com/8790386/151565884-80c8cbc5-ab77-4505-9e4f-b980414354e2.mov


