### PR TITLE
wallet: revert to previous gas price when switching off ludicrous mode

### DIFF
--- a/Balance iOS/Scenes/Wallet/Response/ApproveSendTransactionController.swift
+++ b/Balance iOS/Scenes/Wallet/Response/ApproveSendTransactionController.swift
@@ -20,6 +20,9 @@ class ApproveSendTransactionController: SPDiffableTableController {
     
     private var ludicrousMode = false
     private var referenceGasPriceGwei: UInt
+    private var ludicrousReferenceGasPriceGwei: UInt {
+        get { UInt(ceil(Double(referenceGasPriceGwei) * 1.5)) }
+    }
     
     // MARK: - Views
     
@@ -153,8 +156,7 @@ class ApproveSendTransactionController: SPDiffableTableController {
                     isOn: self.ludicrousMode,
                     action: { (isOn) in
                         self.ludicrousMode = isOn
-                        self.referenceGasPriceGwei = UInt(ceil(Double(self.referenceGasPriceGwei) * (isOn ? 1.5 : 0.5)))
-                        self.transaction.setGasPrice(value: self.referenceGasPriceGwei * UInt(Constants.Ethereum.Units.gwei))
+                        self.transaction.setGasPrice(value: (isOn ? self.ludicrousReferenceGasPriceGwei : self.referenceGasPriceGwei) * UInt(Constants.Ethereum.Units.gwei))
                         self.redraw()
                     }
                 )


### PR DESCRIPTION
This PR reverts to the calculated gas price when ludicrous mode is switched off, fixing a bug where the price got smaller and smaller:

https://user-images.githubusercontent.com/49284/155233372-c305046a-3534-431a-bc54-babecffb5196.mp4

